### PR TITLE
update article.styl

### DIFF
--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -119,13 +119,14 @@ article
       margin-top 15px
 
     blockquote
+      word-wrap:break-word
       border-top 1px solid color-border
       border-bottom 1px solid color-border
       font-style italic
       font-family font-serif
       font-size 1.2em
       padding 0 30px 15px
-      text-align center
+      text-align left
       footer
         border-top none
         font-size 0.8em

--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -113,13 +113,14 @@ article
           text-decoration none
 
   .entry
+    word-wrap break-word
     text-align justify
     line-height 1.6
     p, blockquote, ul, ol, dl, table, iframe, h3, h4, h5, h6, .video-container
       margin-top 15px
 
     blockquote
-      word-wrap:break-word
+      word-wrap break-word
       border-top 1px solid color-border
       border-bottom 1px solid color-border
       font-style italic


### PR DESCRIPTION
fix : When you type some long links in `<blockquote>`,the content will cross the border
update : make the blockquote content to left.